### PR TITLE
Fix invalid YAML schema handling in parser

### DIFF
--- a/src/ezconfy/parser.py
+++ b/src/ezconfy/parser.py
@@ -34,6 +34,9 @@ class SchemaParser:
 
         data = yaml.safe_load(config_str) or {}
 
+        if not isinstance(data, dict):
+            raise SchemaError("Schema document must be a YAML mapping at the top level.")
+
         if "types" in data and "schema" not in data:
             raise SchemaError(
                 "Missing root 'schema' node at top level when 'types' is defined. "
@@ -42,6 +45,9 @@ class SchemaParser:
 
         custom_types_def = data.pop("types", {})
         root_definition = data.pop("schema", data)
+
+        if not isinstance(custom_types_def, dict):
+            raise SchemaError("The 'types' section must be a YAML mapping.")
 
         if not isinstance(root_definition, dict):
             raise SchemaError("Schema definition at top level must be a dictionary.")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -53,6 +53,34 @@ def test_should_raise_schema_error_for_unsupported_type(parser: SchemaParser) ->
     assert "training.early_stopping.patience" in str(exc_info.value)
 
 
+def test_should_raise_schema_error_for_non_mapping_root(parser: SchemaParser) -> None:
+    invalid_config = """
+    - 1
+    - 2
+    """
+
+    with pytest.raises(SchemaError) as exc_info:
+        parser.parse(invalid_config)
+
+    assert "top level" in str(exc_info.value).lower()
+    assert "mapping" in str(exc_info.value).lower()
+
+
+def test_should_raise_schema_error_for_non_mapping_types_section(parser: SchemaParser) -> None:
+    invalid_config = """
+    types:
+      - A
+    schema:
+      value: int
+    """
+
+    with pytest.raises(SchemaError) as exc_info:
+        parser.parse(invalid_config)
+
+    assert "types" in str(exc_info.value).lower()
+    assert "mapping" in str(exc_info.value).lower()
+
+
 @pytest.mark.parametrize(
     "input_data",
     [


### PR DESCRIPTION
This PR fix the parser validation for malformed YAML schema inputs avoiding Python exceptions such as TypeError and AttributeError and using our defined SchemaError one. 

Changes:
* raise a clear SchemaError when the top-level YAML document is not a mapping.
* raise a clear SchemaError when the types section is not a mapping.
* add regression tests for both invalid input cases

Refs #32

@alessioarcara  Let me know wdyt about :). 