### PR TITLE
Added support for dynamic types in the generated config object

### DIFF
--- a/src/ezconfy/codegen/type_utils.py
+++ b/src/ezconfy/codegen/type_utils.py
@@ -1,4 +1,6 @@
+import sys
 from enum import Enum
+from pathlib import Path
 from types import UnionType
 from typing import Any, TypeGuard, Union, get_args, get_origin
 
@@ -7,8 +9,7 @@ from pydantic import BaseModel
 
 def is_union(t: object) -> bool:
     # Handles both `Union[A, B]` (typing) and `A | B` (PEP 604 / UnionType)
-    origin = get_origin(t)
-    return origin is Union or isinstance(t, UnionType)
+    return get_origin(t) is Union or isinstance(t, UnionType)
 
 
 def is_pydantic_model(annotation: Any) -> TypeGuard[type[BaseModel]]:
@@ -23,34 +24,62 @@ def is_builtin(annotation: Any) -> bool:
     return getattr(annotation, "__module__", None) == "builtins"
 
 
-def resolve_type(annotation: type[Any]) -> tuple[str, set[tuple[str, str]]]:
+def is_dynamic(annotation: Any) -> bool:
+    module_name = getattr(annotation, "__module__", "")
+    return module_name.startswith("_dynamic_")
+
+
+def _resolve_args(args: tuple[Any, ...]) -> tuple[list[str], set[tuple[str, str]]]:
+    resolved: list[str] = []
     imports: set[tuple[str, str]] = set()
+    for arg in args:
+        arg_str, arg_imports = resolve_type(arg)
+        resolved.append(arg_str)
+        imports.update(arg_imports)
+    return resolved, imports
+
+
+def _resolve_dynamic_import(module_name: str, type_name: str) -> tuple[str, str] | None:
+    module = sys.modules.get(module_name)
+    if module is None:
+        return None
+    file = getattr(module, "__file__", None)
+    if file is None:
+        return None
+    return (Path(file).stem, type_name)
+
+
+def resolve_type(annotation: type[Any]) -> tuple[str, set[tuple[str, str]]]:
     origin = get_origin(annotation)
 
     if origin is not None:
         args = get_args(annotation)
         if is_union(annotation):
-            non_none_args = [a for a in args if a is not type(None)]
-            has_none = type(None) in args
-            resolved = []
-            for arg in non_none_args:
-                arg_str, arg_imports = resolve_type(arg)
-                resolved.append(arg_str)
-                imports.update(arg_imports)
+            non_none_args = tuple(a for a in args if a is not type(None))
+            resolved, nested_imports = _resolve_args(non_none_args)
             type_str = " | ".join(resolved)
-            if has_none:
+            if type(None) in args:
                 type_str += " | None"
         else:
-            resolved = []
-            for arg in args:
-                arg_str, arg_imports = resolve_type(arg)
-                resolved.append(arg_str)
-                imports.update(arg_imports)
+            resolved, nested_imports = _resolve_args(args)
             origin_name = getattr(origin, "__name__", str(origin))
             type_str = f"{origin_name}[{', '.join(resolved)}]"
-        return type_str, imports
+        return type_str, nested_imports
 
-    type_str = annotation.__name__
+    type_name = getattr(annotation, "__name__", None)
+    if type_name is None:
+        raise TypeError(
+            f"Cannot resolve type name for {annotation!r}. "
+            "Ensure all forward references are resolved before code generation."
+        )
+
+    imports: set[tuple[str, str]] = set()
     if not (is_pydantic_model(annotation) or is_enum(annotation) or is_builtin(annotation)):
-        imports.add((annotation.__module__, annotation.__name__))
-    return type_str, imports
+        module_name = annotation.__module__
+        if is_dynamic(annotation):
+            import_tuple = _resolve_dynamic_import(module_name, type_name)
+            if import_tuple is not None:
+                imports.add(import_tuple)
+        else:
+            imports.add((module_name, type_name))
+    return type_name, imports

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,3 +154,17 @@ def test_generated_code_supports_enum_types(tmp_path: Path, parser: SchemaParser
 
     assert instance.optimizer.value == "adam"
     assert instance.learning_rate.value == 0.01
+
+
+def test_generated_code_with_dynamic_types(tmp_path: Path, parser: SchemaParser) -> None:
+    module_file = tmp_path / "my_model.py"
+    module_file.write_text(
+        "class MyModel:\n    def __init__(self):\n        pass\n",
+        encoding="utf-8",
+    )
+
+    schema = f"model: {module_file}:MyModel\n"
+    _, code = _generate(schema, tmp_path, parser)
+
+    assert "from my_model import MyModel" in code
+    assert "model: MyModel = Field(...)" in code

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "ezconfy"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
## Description

Added support for dynamic types in the generated config object

Closes #36 

## Checklist

- [x] Tests added or updated for the changed behaviour
- [x] All existing tests pass (`uv run pytest`)
- [x] Type checking passes (`uv run mypy src/ezconfy --ignore-missing-imports`)
- [x] Linting passes (`uv run ruff check src tests`)
- [ ] Documentation updated (docstrings, README, or docs/) if needed
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
