### PR TITLE
Add support for inheritance for the generated config

### DIFF
--- a/src/ezconfy/codegen/extractors.py
+++ b/src/ezconfy/codegen/extractors.py
@@ -37,8 +37,14 @@ class ModelExtractor(Extractor):
         imports: set[tuple[str, str]] = {("pydantic", "BaseModel"), ("pydantic", "Field")}
 
         for model in self.results:
+            base = model.__bases__[0]
+            parent_fields = set(base.model_fields.keys()) if is_pydantic_model(base) else set()
+
             field_lines: list[str] = []
             for field_name, field_info in model.model_fields.items():
+                # skip inherited fields to avoid duplication
+                if field_name in parent_fields:
+                    continue
                 annotation = field_info.annotation
                 if annotation is None:
                     logger.error(f"Field '{field_name}' has no type annotation.")
@@ -51,7 +57,7 @@ class ModelExtractor(Extractor):
             if not field_lines:
                 field_lines.append("    pass")
 
-            body.extend(["", "", f"class {model.__name__}(BaseModel):"])
+            body.extend(["", "", f"class {model.__name__}({base.__name__}):"])
             body.extend(field_lines)
 
         return body, imports

--- a/src/ezconfy/core/schema_parser.py
+++ b/src/ezconfy/core/schema_parser.py
@@ -85,15 +85,17 @@ class SchemaParser:
                 raw_name = raw_map[name]
                 self._build_custom_type(raw_name, custom_types_def[raw_name])
 
-    def _build_custom_type(self, raw_name: str, type_def: Any) -> None:
-        base_class = BaseModel
-        name = raw_name.strip()
+    def _parse_inheritance(self, raw_name: str, context: str, path: str) -> tuple[str, type[BaseModel] | Any]:
+        if "<" not in raw_name:
+            return raw_name.strip(), BaseModel
 
-        if "<" in name:
-            name, parent_name = map(str.strip, name.split("<", 1))
-            if parent_name not in self.type_aliases:
-                raise SchemaError(f"Base type '{parent_name}' not defined for '{name}' at '{raw_name}'.")
-            base_class = self.type_aliases[parent_name]
+        name, parent_name = map(str.strip, raw_name.split("<", 1))
+        if parent_name not in self.type_aliases:
+            raise SchemaError(f"Unknown parent type '{parent_name}' for '{name}' at '{path}'.")
+        return name, self.type_aliases[parent_name]
+
+    def _build_custom_type(self, raw_name: str, type_def: Any) -> None:
+        name, base_class = self._parse_inheritance(raw_name, "custom type", raw_name)
 
         self._validate_name(name, "custom type", raw_name)
 
@@ -118,13 +120,15 @@ class SchemaParser:
     ) -> type[BaseModel]:
         model_fields: dict[str, tuple[Any, Any]] = {}
 
-        for field_name, value in data.items():
+        for raw_field_name, value in data.items():
+            field_name, field_base = self._parse_inheritance(raw_field_name, "field", f"{path}.{raw_field_name}")
             field_path = f"{path}.{field_name}" if path else field_name
             self._validate_name(field_name, "field", field_path)
 
             if isinstance(value, dict):
                 nested_name = "".join(w.capitalize() for w in field_name.split("_"))
-                nested_model = self._build_model(nested_name, value, field_path)
+                nested_model = self._build_model(nested_name, value, field_path, base_class=field_base)
+                self.type_aliases[nested_name] = nested_model
                 model_fields[field_name] = (nested_model, Field(...))
             else:
                 parts = [p.strip() for p in str(value).split("=", 1)]

--- a/tests/codegen/test_cli.py
+++ b/tests/codegen/test_cli.py
@@ -168,3 +168,19 @@ def test_generated_code_with_dynamic_types(tmp_path: Path, parser: SchemaParser)
 
     assert "from my_model import MyModel" in code
     assert "model: MyModel = Field(...)" in code
+
+
+def test_generated_code_supports_inheritance(tmp_path: Path, parser: SchemaParser) -> None:
+    schema = """
+schema:
+    A:
+        x: str
+    B < A:
+        y: int
+    """
+    _, code = _generate(schema, tmp_path, parser)
+
+    assert "class A(BaseModel):" in code
+    assert "class B(A):" in code
+    assert "x: str = Field(...)" in code
+    assert "y: int = Field(...)" in code


### PR DESCRIPTION
## Description

Add support for inheritance for the generated config

Closes #35 

## Checklist

- [x] Tests added or updated for the changed behaviour
- [x] All existing tests pass (`uv run pytest`)
- [x] Type checking passes (`uv run mypy src/ezconfy --ignore-missing-imports`)
- [x] Linting passes (`uv run ruff check src tests`)
- [ ] Documentation updated (docstrings, README, or docs/) if needed
- [ ] `CHANGELOG.md` updated under `[Unreleased]`
