### PR TITLE
Added schema-aware type casting and comprehensive documentation   

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9] - 2026-04-22
+
+### Added
+- Schema-aware type casting during instantiation: when a schema is defined, values are now cast to their schema types **before** being passed to `_target_type_` constructors (e.g. a string `"./data"` is cast to `Path("./data")` if the schema declares `data_root: pathlib:Path`)
+
 ## [0.1.8] - 2026-04-21
 
 ### Fixed
@@ -59,7 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External type support (`module:ClassName` and file path syntax)
 - Topological ordering for resolving object instantiation dependencies
 
-[Unreleased]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.8...HEAD
+[Unreleased]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.9...HEAD
+[0.1.9]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.5...v0.1.7
 [0.1.5]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.4...v0.1.5

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 <p align="center">
-  <img src="docs/logo.svg" alt="ezconfy logo" width="280" />
+  <img src="docs/logo.svg" alt="EzConfy logo" width="280" />
 </p>
 
-## Why ezconfy?
+<p align="center">
+  <strong>YAML-based configuration with Pydantic validation and dynamic object instantiation.</strong>
+</p>
 
-EzConfy is designed for ML projects that want **typed, validated configs with automatic object wiring** - without the complexity of a full framework like Hydra.
+<p align="center">
+  <a href="https://pypi.org/project/ezconfy/"><img src="https://img.shields.io/pypi/v/ezconfy?color=blue&label=PyPI" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/ezconfy/"><img src="https://img.shields.io/pypi/pyversions/ezconfy" alt="Python versions"></a>
+  <a href="https://github.com/alessioarcara/EzConfy/blob/main/LICENSE"><img src="https://img.shields.io/github/license/alessioarcara/EzConfy" alt="License"></a>
+</p>
 
-## Installation
+---
 
-```bash
-pip install ezconfy
-```
+## Why EzConfy?
 
-## Quick Start
-
-Define a schema and a config file, then load them:
+ML projects constantly deal with configuration: learning rates, model parameters, dataset options, augmentation pipelines. EzConfy gives you **typed, validated configs with automatic object wiring** — without the complexity of a full framework like Hydra.
 
 ```python
 from ezconfy import ConfigBuilder
@@ -23,9 +25,58 @@ cfg = ConfigBuilder.from_files(config_paths="config.yaml", schema_path="schema.y
 print(cfg.training.batch_size)  # validated, typed access
 ```
 
+### What you get
+
+| Feature | Description |
+|---------|-------------|
+| **Pydantic validation** | Type checking with clear error messages |
+| **Schema-aware casting** | Strings become `Path` objects, etc. — before constructors run |
+| **Dynamic instantiation** | Construct any Python class from YAML via `_target_type_` |
+| **Placeholders** | `${key}`, attribute access, method calls, arithmetic |
+| **Multi-file merge** | Split configs across files, override per experiment |
+| **Code generation** | Generate Pydantic models for editor autocompletion |
+
+## Installation
+
+```bash
+pip install ezconfy
+```
+
+Requires Python 3.11+.
+
+## Quick Start
+
+**config.yaml**
+```yaml
+lr: 0.001
+batch_size: 32
+data_path: ./data
+```
+
+**schema.yaml**
+```yaml
+lr: float
+batch_size: int
+data_path: pathlib:Path
+```
+
+**train.py**
+```python
+from ezconfy import ConfigBuilder
+
+cfg = ConfigBuilder.from_files(
+    config_paths="config.yaml",
+    schema_path="schema.yaml",
+)
+
+print(cfg.lr)          # 0.001 (float)
+print(cfg.batch_size)  # 32 (int)
+print(cfg.data_path)   # PosixPath('data') — automatically cast
+```
+
 ## Schema
 
-A schema file describes the expected shape and types of your configuration. It can define custom types and the root structure:
+A schema file describes the expected shape and types of your configuration:
 
 ```yaml
 types:
@@ -45,10 +96,13 @@ schema:
     optimizer: OptimizerType
 ```
 
-### Supported type syntax
+If no `types` are needed, the entire YAML is treated as the root schema (no `schema:` wrapper required).
+
+<details>
+<summary><strong>Supported type syntax</strong></summary>
 
 | Syntax | Meaning |
-|---|---|
+|--------|---------|
 | `int`, `float`, `str`, `bool` | Primitive types |
 | `type?` | Optional (defaults to `None`) |
 | `type = value` | Type with default |
@@ -59,11 +113,11 @@ schema:
 | `pathlib:Path` | External type (import path) |
 | `/path/to/file.py:ClassName` | External type (file path) |
 
-If no `types` are needed, the entire YAML is treated as the root schema (no `schema:` wrapper required).
+</details>
 
 ## Object Instantiation
 
-ezconfy can instantiate Python objects directly from config using `_target_type_`:
+Construct Python objects directly from config using `_target_type_`:
 
 ```yaml
 dataset:
@@ -73,7 +127,7 @@ dataset:
     root: /data
 ```
 
-Use `_init_method_` to call an alternative constructor (e.g. `from_pretrained`):
+Use `_init_method_` for alternative constructors (e.g. `from_pretrained`):
 
 ```yaml
 encoder:
@@ -83,33 +137,38 @@ encoder:
     model_name: bert-base-uncased
 ```
 
-## Placeholder Injection
+## Placeholders & Expressions
 
-Reference other config values with `${key}`. Supports attribute access and method calls:
+Reference other config values with `${key}`. Supports attribute access, method calls, and arithmetic:
 
 ```yaml
+lr: 0.001
+warmup_lr: ${lr * 10}                       # arithmetic
+
 num_classes: 10
 
 dataset:
   _target_type_: mypackage.data:MyDataset
   _init_args_:
-    num_classes: ${num_classes}   # scalar reference
+    num_classes: ${num_classes}               # scalar reference
 
 model:
   _target_type_: mypackage.models:Classifier
   _init_args_:
-    in_features: ${dataset.num_classes}   # attribute access
-    params: ${encoder.parameters()}       # method call
+    in_features: ${dataset.num_classes}       # attribute access
+    params: ${encoder.parameters()}           # method call
 ```
 
-Objects are instantiated in topological order based on their dependencies, so forward references work automatically.
+Objects are instantiated in topological order based on their dependencies — forward references work automatically.
 
 ## Multi-file Configs & Overrides
 
 Pass multiple files — they are deep-merged in order (later files win on conflicts):
 
 ```python
-cfg = ConfigBuilder.from_files(config_paths=["base.yaml", "experiment.yaml"])
+cfg = ConfigBuilder.from_files(
+    config_paths=["base.yaml", "experiment.yaml"],
+)
 ```
 
 Apply programmatic overrides on top:
@@ -123,14 +182,16 @@ cfg = ConfigBuilder.from_files(
 
 ## Code Generation CLI
 
-Generate a Pydantic model file from a schema:
+Generate a Pydantic model file from a schema for editor autocompletion and static analysis:
 
 ```bash
-ezconfy generate schema.yaml output.py
+ezconfy generate schema.yaml -o models.py
 ```
 
-This produces a standalone `.py` file with `BaseModel` classes matching the schema, useful for editor autocompletion and static analysis.
+## Documentation
 
-## Requirements
+Full documentation: [alessioarcara.github.io/EzConfy](https://alessioarcara.github.io/EzConfy/)
 
-- Python 3.11+
+## License
+
+[MIT](LICENSE)

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -1,0 +1,131 @@
+# Code Generation CLI
+
+EzConfy can generate standalone Python files with Pydantic model definitions from your schema. This gives you editor autocompletion, type checking, and documentation for your config structure — without writing the models by hand.
+
+---
+
+## Usage
+
+```bash
+ezconfy generate schema.yaml -o models.py
+```
+
+This reads `schema.yaml` and writes a Python file with `BaseModel` classes matching the schema.
+
+---
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `schema_path` | *(required)* | Path to the YAML schema file |
+| `-o`, `--output` | `generated.py` | Output file path |
+
+---
+
+## Example
+
+=== "schema.yaml"
+
+    ```yaml
+    types:
+      OptimizerType:
+        - adam
+        - sgd
+
+      TrainingConfig:
+        lr: float = 0.001
+        epochs: int = 10
+        optimizer: OptimizerType
+
+    schema:
+      training: TrainingConfig
+      name: str
+      debug: bool?
+    ```
+
+=== "Generated output"
+
+    ```python
+    from enum import Enum
+
+    from pydantic import BaseModel, ConfigDict
+
+
+    class OptimizerType(Enum):
+        V0 = "adam"
+        V1 = "sgd"
+
+
+    class TrainingConfig(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        lr: float = 0.001
+        epochs: int = 10
+        optimizer: OptimizerType
+
+
+    class ConfigModel(BaseModel):
+        model_config = ConfigDict(arbitrary_types_allowed=True)
+
+        training: TrainingConfig
+        name: str
+        debug: bool | None = None
+    ```
+
+---
+
+## Why Generate Code?
+
+<div class="grid cards" markdown>
+
+-   :material-auto-fix:{ .lg .middle } **Editor autocompletion**
+
+    ---
+
+    Your IDE knows every config field and its type.
+
+-   :material-check-decagram:{ .lg .middle } **Static analysis**
+
+    ---
+
+    `mypy` and other type checkers can verify your config usage.
+
+-   :material-book-open-variant:{ .lg .middle } **Documentation**
+
+    ---
+
+    The generated file acts as a readable reference for your config structure.
+
+-   :material-shield-refresh-outline:{ .lg .middle } **Refactoring safety**
+
+    ---
+
+    Renaming a field in the schema and regenerating catches all usages.
+
+</div>
+
+---
+
+## Workflow
+
+A typical workflow:
+
+1. Define or update `schema.yaml`
+2. Run `ezconfy generate schema.yaml -o config_models.py`
+3. Import the generated models for type hints:
+
+```python
+from config_models import ConfigModel
+from ezconfy import ConfigBuilder
+
+cfg: ConfigModel = ConfigBuilder.from_files(  # type: ignore[assignment]
+    config_paths="config.yaml",
+    schema_path="schema.yaml",
+)
+
+# Now your editor knows about cfg.training.lr, cfg.name, etc.
+```
+
+!!! tip
+    Regenerate whenever the schema changes to keep your type hints in sync.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,189 @@
+# Getting Started
+
+This tutorial walks you through EzConfy from scratch. By the end you will have a validated, typed configuration that automatically constructs Python objects — all from a simple YAML file.
+
+---
+
+## 1. Install EzConfy
+
+```bash
+pip install ezconfy
+```
+
+---
+
+## 2. Create a config file
+
+A config file is just a YAML file. Create `config.yaml`:
+
+```yaml
+project_name: my-experiment
+lr: 0.001
+epochs: 10
+data_path: ./data
+```
+
+---
+
+## 3. Load it in Python
+
+```python
+from ezconfy import ConfigBuilder
+
+cfg = ConfigBuilder.from_files(config_paths="config.yaml")
+```
+
+Without a schema, `cfg` is a plain dictionary:
+
+```python
+print(cfg["lr"])          # 0.001
+print(cfg["data_path"])   # './data' (a string — not a Path object)
+```
+
+!!! note "Why a dictionary?"
+    Without a schema, EzConfy has no type information. The result is a raw dictionary with YAML-parsed values. Adding a schema upgrades this to a validated Pydantic model.
+
+---
+
+## 4. Add a schema
+
+A schema tells EzConfy what types your config values should have. Create `schema.yaml`:
+
+```yaml
+project_name: str
+lr: float
+epochs: int
+data_path: pathlib:Path
+```
+
+Now load with the schema:
+
+```python
+cfg = ConfigBuilder.from_files(
+    config_paths="config.yaml",
+    schema_path="schema.yaml",
+)
+
+print(cfg.lr)          # 0.001 (float — validated)
+print(cfg.data_path)   # PosixPath('./data') — automatically cast
+print(cfg.epochs)      # 10 (int — validated)
+```
+
+!!! tip "What changed?"
+    1. **Dot access** — `cfg.lr` instead of `cfg["lr"]`. With a schema, the result is a Pydantic model.
+    2. **Automatic casting** — `data_path` is now a real `Path` object, not a string.
+
+    If you make a typo in the config (e.g. `epochs: "ten"`), EzConfy raises a clear validation error immediately.
+
+---
+
+## 5. Instantiate objects
+
+Here is where EzConfy gets really useful. Instead of writing boilerplate to construct objects from config values, let EzConfy do it for you.
+
+Say you have a `Dataset` class:
+
+```python
+# my_project/data.py
+class Dataset:
+    def __init__(self, root: str, num_classes: int):
+        self.root = root
+        self.num_classes = num_classes
+```
+
+In your config, use `_target_type_` to tell EzConfy which class to instantiate and `_init_args_` for the constructor arguments:
+
+=== "config.yaml"
+
+    ```yaml
+    num_classes: 10
+
+    dataset:
+      _target_type_: my_project.data:Dataset
+      _init_args_:
+        root: ./data
+        num_classes: ${num_classes}
+    ```
+
+=== "Python"
+
+    ```python
+    cfg = ConfigBuilder.from_files(config_paths="config.yaml")
+
+    print(cfg["dataset"])              # <my_project.data.Dataset object>
+    print(cfg["dataset"].root)         # './data'
+    print(cfg["dataset"].num_classes)  # 10
+    ```
+
+!!! info "Placeholder resolution"
+    The `${num_classes}` placeholder pulls the value from the top-level `num_classes` key. EzConfy resolves dependencies automatically — objects that depend on other objects are instantiated in the correct order.
+
+---
+
+## 6. Combine schema + instantiation
+
+For full validation with object instantiation:
+
+=== "schema.yaml"
+
+    ```yaml
+    types:
+      Dataset: my_project.data:Dataset
+
+    schema:
+      num_classes: int
+      dataset: Dataset
+    ```
+
+=== "Python"
+
+    ```python
+    cfg = ConfigBuilder.from_files(
+        config_paths="config.yaml",
+        schema_path="schema.yaml",
+    )
+
+    print(cfg.dataset)              # <Dataset object> — validated
+    print(cfg.dataset.num_classes)  # 10 — typed correctly
+    ```
+
+---
+
+## 7. Override per experiment
+
+You can split your config into a base file and experiment-specific overrides:
+
+```python
+cfg = ConfigBuilder.from_files(
+    config_paths=["base.yaml", "experiment_large.yaml"],
+)
+```
+
+Later files win on conflicts. You can also pass overrides programmatically:
+
+```python
+cfg = ConfigBuilder.from_files(
+    config_paths="config.yaml",
+    overrides={"lr": 0.01, "epochs": 50},
+)
+```
+
+---
+
+## Summary
+
+| Step | What you get |
+|------|-------------|
+| Config YAML only | Plain dictionary with raw values |
+| + Schema | Pydantic model with validation, typing, and automatic casting |
+| + `_target_type_` | Fully constructed Python objects from config |
+| + Placeholders | Cross-references between config values |
+| + Multi-file | Experiment overrides without duplicating config |
+
+---
+
+## Next Steps
+
+- **[Schema & Validation](schema.md)** — full type syntax reference
+- **[Object Instantiation](instantiation.md)** — `_target_type_`, `_init_method_`, and dependency ordering
+- **[Placeholders & Expressions](placeholders.md)** — `${key}`, attribute access, method calls, arithmetic

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,205 @@
-# Welcome to EasyConfig
+---
+hide:
+  - navigation
+  - toc
+---
 
-...
+<style>
+.md-typeset h1 { display: none; }
+</style>
+
+<div class="hero" markdown>
+
+<p align="center">
+  <img src="logo.svg" alt="EzConfy logo" width="280" />
+</p>
+
+<p align="center" class="hero-tagline" style="font-size: 1.3em; opacity: 0.8; margin-top: -0.5em;">
+  <strong>YAML-based configuration with Pydantic validation and dynamic object instantiation.</strong>
+</p>
+
+<p align="center">
+  <a href="https://pypi.org/project/ezconfy/"><img src="https://img.shields.io/pypi/v/ezconfy?color=blue&label=PyPI" alt="PyPI version"></a>
+  <a href="https://pypi.org/project/ezconfy/"><img src="https://img.shields.io/pypi/pyversions/ezconfy" alt="Python versions"></a>
+  <a href="https://github.com/alessioarcara/EzConfy/blob/main/LICENSE"><img src="https://img.shields.io/github/license/alessioarcara/EzConfy" alt="License"></a>
+</p>
+
+</div>
+
+---
+
+## The Problem
+
+If you have ever written a Python project — especially in machine learning — you have probably dealt with configuration: learning rates, file paths, model parameters, dataset options. At first you hard-code them, then you move them to a dictionary, then maybe a YAML file. But soon you run into problems:
+
+<div class="grid cards" markdown>
+
+-   :material-alert-circle-outline:{ .lg .middle } **No validation**
+
+    ---
+
+    Misspell a key (`lerning_rate` instead of `learning_rate`) and nothing complains — the value is silently ignored. Pass a string where an integer is expected and you get a crash deep in your training loop.
+
+-   :material-code-tags:{ .lg .middle } **No typing**
+
+    ---
+
+    Every value is a raw string or number. If your code expects a `Path` object, you have to remember to convert it yourself.
+
+-   :material-link-variant-off:{ .lg .middle } **No wiring**
+
+    ---
+
+    You load config values but still have to manually write `MyDataset(num_classes=config["num_classes"])` everywhere.
+
+-   :material-code-braces:{ .lg .middle } **Too much boilerplate**
+
+    ---
+
+    As configs grow, the glue code between "reading a YAML file" and "having usable objects" keeps expanding.
+
+</div>
+
+**EzConfy eliminates all of this.** Write a YAML config, optionally define a schema, and get back fully instantiated, validated Python objects — ready to use.
+
+---
+
+## Key Features
+
+<div class="grid cards" markdown>
+
+-   :material-file-document-outline:{ .lg .middle } **YAML config files**
+
+    ---
+
+    Human-readable, easy to diff and version-control.
+
+-   :material-shield-check-outline:{ .lg .middle } **Pydantic validation**
+
+    ---
+
+    Define a schema and get automatic type checking with clear error messages.
+
+-   :material-swap-horizontal:{ .lg .middle } **Schema-aware type casting**
+
+    ---
+
+    Values are cast to schema types *before* constructors run — strings become `Path` objects automatically.
+
+-   :material-cog-outline:{ .lg .middle } **Dynamic object instantiation**
+
+    ---
+
+    Construct any Python class from config using `_target_type_`.
+
+-   :material-variable:{ .lg .middle } **Placeholders & expressions**
+
+    ---
+
+    Reference other values with `${key}`, including attribute access, method calls, and arithmetic.
+
+-   :material-file-multiple-outline:{ .lg .middle } **Multi-file deep merge**
+
+    ---
+
+    Split configs across files, override per experiment — later files win.
+
+-   :material-console:{ .lg .middle } **Code generation CLI**
+
+    ---
+
+    Generate Pydantic model files from your schema for editor autocompletion.
+
+</div>
+
+---
+
+## Installation
+
+```bash
+pip install ezconfy
+```
+
+!!! info "Requirements"
+    Python 3.11 or later.
+
+---
+
+## Quick Example
+
+=== "config.yaml"
+
+    ```yaml
+    lr: 0.001
+    batch_size: 32
+    data_path: ./data
+    ```
+
+=== "schema.yaml"
+
+    ```yaml
+    lr: float
+    batch_size: int
+    data_path: pathlib:Path
+    ```
+
+=== "train.py"
+
+    ```python
+    from ezconfy import ConfigBuilder
+
+    cfg = ConfigBuilder.from_files(
+        config_paths="config.yaml",
+        schema_path="schema.yaml",
+    )
+
+    print(cfg.lr)          # 0.001 (float)
+    print(cfg.batch_size)  # 32 (int)
+    print(cfg.data_path)   # PosixPath('data') — automatically cast
+    ```
+
+Three files, three lines of Python, and you get validated, typed configuration.
+
+---
+
+## What's Next?
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch-outline:{ .lg .middle } **[Getting Started](getting-started.md)**
+
+    ---
+
+    A step-by-step tutorial from zero to a working config.
+
+-   :material-shield-check-outline:{ .lg .middle } **[Schema & Validation](schema.md)**
+
+    ---
+
+    The full type syntax reference.
+
+-   :material-cog-outline:{ .lg .middle } **[Object Instantiation](instantiation.md)**
+
+    ---
+
+    Construct Python objects directly from YAML.
+
+-   :material-variable:{ .lg .middle } **[Placeholders & Expressions](placeholders.md)**
+
+    ---
+
+    Reference and compute across config values.
+
+-   :material-file-multiple-outline:{ .lg .middle } **[Multi-file Configs](multi-file.md)**
+
+    ---
+
+    Split, merge, and override configurations.
+
+-   :material-console:{ .lg .middle } **[Code Generation](codegen.md)**
+
+    ---
+
+    Generate Pydantic models from your schema.
+
+</div>

--- a/docs/instantiation.md
+++ b/docs/instantiation.md
@@ -1,0 +1,243 @@
+# Object Instantiation
+
+## Why Use Object Instantiation?
+
+In ML and deep learning projects, you constantly swap components: try a different backbone, switch the optimizer, change the learning rate scheduler, replace the data augmentation pipeline. Without a config-driven approach, every change means editing Python code:
+
+```python
+# Want to try SGD instead of Adam? Edit code.
+# Want ResNet50 instead of ResNet18? Edit code.
+# Want CosineAnnealing instead of StepLR? Edit code.
+optimizer = Adam(model.parameters(), lr=0.001)
+```
+
+This makes **ablation studies** painful — each experiment requires a code change, and tracking what you tried becomes a mess of git branches or commented-out lines.
+
+With EzConfy, swapping a component is a one-line YAML change:
+
+=== "experiment_a.yaml"
+
+    ```yaml
+    optimizer:
+      _target_type_: torch.optim:Adam
+      _init_args_:
+        params: ${model.parameters()}
+        lr: 0.001
+    ```
+
+=== "experiment_b.yaml"
+
+    ```yaml
+    optimizer:
+      _target_type_: torch.optim:SGD
+      _init_args_:
+        params: ${model.parameters()}
+        lr: 0.01
+        momentum: 0.9
+    ```
+
+Your training script stays **exactly the same** — it just reads `cfg.optimizer` and uses whatever was configured. This means you can:
+
+- **Run ablation studies** by swapping config files, not code
+- **Track experiments** by versioning YAML files (each file is a complete record of what was used)
+- **Share configurations** with teammates without them needing to understand the codebase
+- **Compose pipelines** — datasets, models, optimizers, schedulers, metrics — all wired together in YAML
+
+The training code becomes a generic loop that works with any combination of components:
+
+```python
+cfg = ConfigBuilder.from_files(
+    config_paths=["configs/base.yaml", f"configs/{experiment}.yaml"],
+    schema_path="schema.yaml",
+)
+
+for epoch in range(cfg.epochs):
+    train_one_epoch(cfg.model, cfg.train_loader, cfg.optimizer, cfg.criterion)
+    evaluate(cfg.model, cfg.test_loader, cfg.metric)
+    cfg.scheduler.step()
+```
+
+---
+
+## Basic Usage
+
+Use `_target_type_` to specify the class and `_init_args_` for constructor arguments:
+
+```yaml
+dataset:
+  _target_type_: my_project.data:MyDataset
+  _init_args_:
+    root: ./data
+    num_classes: 10
+```
+
+This is equivalent to `MyDataset(root='./data', num_classes=10)`.
+
+!!! info "Import path format"
+    The `_target_type_` value is an import path in the format `module.path:ClassName`. EzConfy dynamically imports the class and calls its constructor.
+
+---
+
+## Import Path Formats
+
+EzConfy supports two ways to reference a class:
+
+| Format | Example | When to use |
+|--------|---------|-------------|
+| Module path | `my_project.data:MyDataset` | Installed packages or importable modules |
+| File path | `./models/nn.py:MLP` | Scripts or files not on `sys.path` |
+
+Both absolute and relative file paths work.
+
+---
+
+## Alternative Constructors
+
+Some classes use factory methods or classmethods instead of `__init__`. Use `_init_method_` to call an alternative constructor:
+
+```yaml
+encoder:
+  _target_type_: transformers:AutoModel
+  _init_method_: from_pretrained
+  _init_args_:
+    pretrained_model_name_or_path: bert-base-uncased
+```
+
+This calls `AutoModel.from_pretrained(pretrained_model_name_or_path='bert-base-uncased')`.
+
+---
+
+## Dependency Ordering
+
+EzConfy resolves dependencies automatically using topological sorting. If one object references another via a placeholder, EzConfy instantiates them in the correct order:
+
+```yaml
+model:
+  _target_type_: torch.nn:Linear
+  _init_args_:
+    in_features: 784
+    out_features: 10
+
+optimizer:
+  _target_type_: torch.optim:Adam
+  _init_args_:
+    params: ${model.parameters()}   # model is instantiated first
+    lr: 0.001
+```
+
+!!! tip
+    You don't need to worry about ordering in your YAML — EzConfy figures it out from the `${}` references.
+
+!!! warning "Circular dependencies"
+    If there is a circular dependency (A depends on B, B depends on A), EzConfy raises an error with a clear message.
+
+---
+
+## Nested Instantiation
+
+Objects can be nested inside lists or other objects:
+
+```yaml
+transform:
+  _target_type_: torchvision.transforms:Compose
+  _init_args_:
+    transforms:
+      - _target_type_: torchvision.transforms:ToTensor
+      - _target_type_: torchvision.transforms:Normalize
+        _init_args_:
+          mean: [0.1307]
+          std: [0.3081]
+```
+
+This creates a `Compose` containing a `ToTensor` and a `Normalize` — all wired up automatically.
+
+---
+
+## Complete Example: Ablation-Ready Training
+
+Here is a realistic project layout where swapping any component is a YAML change:
+
+```
+project/
+  configs/
+    base.yaml             # shared defaults
+    resnet18.yaml          # backbone = ResNet18
+    resnet50.yaml          # backbone = ResNet50
+    cosine_scheduler.yaml  # lr scheduler = CosineAnnealing
+    step_scheduler.yaml    # lr scheduler = StepLR
+  schema.yaml
+  train.py
+```
+
+=== "configs/base.yaml"
+
+    ```yaml
+    num_classes: 10
+    lr: 0.001
+    epochs: 20
+
+    dataset:
+      _target_type_: torchvision.datasets:MNIST
+      _init_args_:
+        root: ./data
+        train: true
+        download: true
+
+    optimizer:
+      _target_type_: torch.optim:Adam
+      _init_args_:
+        params: ${model.parameters()}
+        lr: ${lr}
+
+    criterion:
+      _target_type_: torch.nn:CrossEntropyLoss
+    ```
+
+=== "configs/resnet18.yaml"
+
+    ```yaml
+    model:
+      _target_type_: torchvision.models:resnet18
+      _init_args_:
+        num_classes: ${num_classes}
+    ```
+
+=== "configs/resnet50.yaml"
+
+    ```yaml
+    model:
+      _target_type_: torchvision.models:resnet50
+      _init_args_:
+        num_classes: ${num_classes}
+    ```
+
+=== "train.py"
+
+    ```python
+    import sys
+    from ezconfy import ConfigBuilder
+
+    backbone = sys.argv[1]  # "resnet18" or "resnet50"
+
+    cfg = ConfigBuilder.from_files(
+        config_paths=["configs/base.yaml", f"configs/{backbone}.yaml"],
+        schema_path="schema.yaml",
+    )
+
+    for epoch in range(cfg.epochs):
+        for data, target in DataLoader(cfg["dataset"]):
+            output = cfg["model"](data)
+            loss = cfg["criterion"](output, target)
+            cfg["optimizer"].zero_grad()
+            loss.backward()
+            cfg["optimizer"].step()
+    ```
+
+Running ablations is now just:
+
+```bash
+python train.py resnet18
+python train.py resnet50
+```
+
+No code changes. Each YAML file is a complete, reproducible record of the experiment configuration.

--- a/docs/multi-file.md
+++ b/docs/multi-file.md
@@ -1,0 +1,222 @@
+# Multi-file Configs & Overrides
+
+Real projects don't have a single, fixed configuration. You run different experiments, try different augmentation pipelines, swap schedulers, test on different datasets. Copying entire config files for each variation leads to duplication and drift.
+
+EzConfy solves this with multi-file merging and programmatic overrides.
+
+---
+
+## The Idea: One Base, Many Variations
+
+The core pattern is simple:
+
+1. **A base config** defines everything that stays the same across experiments
+2. **Small override files** each change only the part that varies
+3. You **compose** them at load time — later files override earlier ones
+
+Your training script never changes. You just pick which YAML files to combine.
+
+---
+
+## Multiple Config Files
+
+Pass a list of files to `config_paths`. They are deep-merged in order — later files win on conflicts:
+
+```python
+cfg = ConfigBuilder.from_files(
+    config_paths=["configs/base.yaml", "configs/heavy_augment.yaml"],
+)
+```
+
+=== "configs/base.yaml"
+
+    ```yaml
+    epochs: 50
+    lr: 0.001
+    batch_size: 32
+
+    model:
+      _target_type_: torchvision.models:resnet18
+      _init_args_:
+        num_classes: 10
+
+    augmentation:
+      _target_type_: torchvision.transforms:Compose
+      _init_args_:
+        transforms:
+          - _target_type_: torchvision.transforms:ToTensor
+
+    optimizer:
+      _target_type_: torch.optim:Adam
+      _init_args_:
+        params: ${model.parameters()}
+        lr: ${lr}
+
+    scheduler:
+      _target_type_: torch.optim.lr_scheduler:StepLR
+      _init_args_:
+        optimizer: ${optimizer}
+        step_size: 10
+    ```
+
+=== "configs/heavy_augment.yaml"
+
+    ```yaml
+    augmentation:
+      _target_type_: torchvision.transforms:Compose
+      _init_args_:
+        transforms:
+          - _target_type_: torchvision.transforms:RandomHorizontalFlip
+          - _target_type_: torchvision.transforms:RandomCrop
+            _init_args_:
+              size: 32
+              padding: 4
+          - _target_type_: torchvision.transforms:ToTensor
+          - _target_type_: torchvision.transforms:Normalize
+            _init_args_:
+              mean: [0.4914, 0.4822, 0.4465]
+              std: [0.2470, 0.2435, 0.2616]
+    ```
+
+!!! tip "Result"
+    The model, optimizer, scheduler, and training params come from `base.yaml`. Only `augmentation` is replaced by `heavy_augment.yaml`. Everything else is untouched.
+
+---
+
+## Deep Merge Behavior
+
+Nested dictionaries are merged recursively, not replaced entirely:
+
+=== "base.yaml"
+
+    ```yaml
+    training:
+      lr: 0.001
+      epochs: 10
+      batch_size: 32
+    ```
+
+=== "override.yaml"
+
+    ```yaml
+    training:
+      lr: 0.01
+    ```
+
+=== "Result"
+
+    ```yaml
+    training:
+      lr: 0.01        # overridden
+      epochs: 10      # preserved from base
+      batch_size: 32  # preserved from base
+    ```
+
+!!! note
+    Non-dict values (scalars, lists) are fully replaced by the later file.
+
+---
+
+## Composing Multiple Override Files
+
+You are not limited to two files. Combine a base with several focused override files, each responsible for one concern:
+
+```python
+cfg = ConfigBuilder.from_files(
+    config_paths=[
+        "configs/base.yaml",            # full baseline
+        "configs/resnet50.yaml",         # swap backbone
+        "configs/cosine_scheduler.yaml", # swap scheduler
+        "configs/heavy_augment.yaml",    # swap augmentation
+    ],
+)
+```
+
+Each override file is small and single-purpose:
+
+=== "configs/resnet50.yaml"
+
+    ```yaml
+    model:
+      _target_type_: torchvision.models:resnet50
+      _init_args_:
+        num_classes: ${num_classes}
+    ```
+
+=== "configs/cosine_scheduler.yaml"
+
+    ```yaml
+    scheduler:
+      _target_type_: torch.optim.lr_scheduler:CosineAnnealingLR
+      _init_args_:
+        optimizer: ${optimizer}
+        T_max: ${epochs}
+    ```
+
+Mix and match components freely. Want ResNet50 with heavy augmentation and cosine scheduler? Combine those three files. Want ResNet18 with light augmentation and step scheduler? Use just the base. No duplication, no drift.
+
+---
+
+## Programmatic Overrides
+
+For quick tweaks — hyperparameter sweeps, CLI arguments, test-specific values — pass an `overrides` dictionary. It is applied after all files are merged, so it always wins:
+
+```python
+cfg = ConfigBuilder.from_files(
+    config_paths=["configs/base.yaml", "configs/resnet50.yaml"],
+    overrides={"lr": 0.01, "batch_size": 128},
+)
+```
+
+!!! example "Hyperparameter sweep"
+
+    ```python
+    for lr in [0.1, 0.01, 0.001, 0.0001]:
+        cfg = ConfigBuilder.from_files(
+            config_paths=["configs/base.yaml"],
+            overrides={"lr": lr},
+        )
+        train(cfg)
+    ```
+
+---
+
+## Typical Project Layout
+
+```
+project/
+  configs/
+    base.yaml                # complete baseline experiment
+    backbones/
+      resnet18.yaml          # swap backbone to ResNet18
+      resnet50.yaml          # swap backbone to ResNet50
+    augmentations/
+      light.yaml             # minimal augmentation
+      heavy.yaml             # aggressive augmentation
+    schedulers/
+      step.yaml              # StepLR scheduler
+      cosine.yaml            # CosineAnnealing scheduler
+  schema.yaml                # validation schema
+  train.py
+```
+
+```python
+# train.py
+import sys
+from ezconfy import ConfigBuilder
+
+# Example: python train.py resnet50 heavy cosine
+backbone, augment, scheduler = sys.argv[1], sys.argv[2], sys.argv[3]
+
+cfg = ConfigBuilder.from_files(
+    config_paths=[
+        "configs/base.yaml",
+        f"configs/backbones/{backbone}.yaml",
+        f"configs/augmentations/{augment}.yaml",
+        f"configs/schedulers/{scheduler}.yaml",
+    ],
+    schema_path="schema.yaml",
+)
+```
+
+Each experiment is fully described by its combination of YAML files — easy to reproduce, easy to compare, easy to version-control.

--- a/docs/placeholders.md
+++ b/docs/placeholders.md
@@ -1,0 +1,155 @@
+# Placeholders & Expressions
+
+Placeholders let you reference one config value from another using `${key}` syntax. This avoids duplicating values and lets EzConfy wire objects together automatically.
+
+---
+
+## Basic References
+
+Reference a top-level key:
+
+```yaml
+num_classes: 10
+
+dataset:
+  _target_type_: my_project.data:MyDataset
+  _init_args_:
+    num_classes: ${num_classes}   # resolves to 10
+```
+
+The placeholder `${num_classes}` is replaced with the value of the `num_classes` key.
+
+---
+
+## Attribute Access
+
+Access attributes on instantiated objects with dot notation:
+
+```yaml
+dataset:
+  _target_type_: my_project.data:MyDataset
+  _init_args_:
+    num_classes: 5
+
+model:
+  _target_type_: my_project.models:Classifier
+  _init_args_:
+    output_dim: ${dataset.num_classes}   # resolves to 5
+```
+
+!!! info
+    This works because `dataset` is instantiated first (EzConfy resolves dependencies), then `dataset.num_classes` reads the attribute from the instantiated `MyDataset` object.
+
+---
+
+## Method Calls
+
+Call methods on instantiated objects by appending `()`:
+
+```yaml
+model:
+  _target_type_: torch.nn:Linear
+  _init_args_:
+    in_features: 784
+    out_features: 10
+
+optimizer:
+  _target_type_: torch.optim:Adam
+  _init_args_:
+    params: ${model.parameters()}   # calls model.parameters()
+    lr: 0.001
+```
+
+!!! warning "Limitation"
+    Only no-argument methods are supported (e.g. `parameters()`, `state_dict()`).
+
+---
+
+## Nested Dictionary Access
+
+When a config value is a plain dictionary (no `_target_type_`), access nested keys with dot notation:
+
+```yaml
+training:
+  lr: 0.001
+  batch_size: 32
+
+warmup_lr: ${training.lr}   # resolves to 0.001
+```
+
+---
+
+## Arithmetic Expressions
+
+Placeholders support arithmetic with `+`, `-`, `*`, `/`, `//`, `%`, and `**`:
+
+```yaml
+lr: 0.001
+warmup_lr: ${lr * 10}            # 0.01
+weight_decay: ${lr / 10}         # 0.0001
+
+a: 3
+b: 7
+total: ${a + b}                  # 10
+half: ${a // 2}                  # 1
+```
+
+You can mix references and literals:
+
+```yaml
+dataset:
+  _target_type_: my_project.data:MyDataset
+  _init_args_:
+    num_classes: 5
+
+model:
+  _target_type_: my_project.models:Classifier
+  _init_args_:
+    hidden_dim: ${dataset.num_classes * 4}   # 20
+```
+
+Unary operators also work:
+
+```yaml
+value: 5
+negated: ${-value}   # -5
+```
+
+---
+
+## How Dependency Resolution Works
+
+EzConfy scans all `${}` references, builds a dependency graph, and processes keys in topological order:
+
+1. Keys with no dependencies are resolved first
+2. Keys that reference already-resolved values are resolved next
+3. This continues until all keys are processed
+
+```yaml
+# Resolution order: a -> b -> c
+a: 1
+b: ${a}       # depends on a
+c: ${a + b}   # depends on a and b
+```
+
+!!! warning "Circular dependencies"
+    If you create a circular dependency, EzConfy raises an error:
+
+    ```yaml
+    # This will fail with "Circular reference detected"
+    a: ${b}
+    b: ${a}
+    ```
+
+---
+
+## Rules and Limitations
+
+!!! abstract "Quick reference"
+
+    | Rule | Example |
+    |------|---------|
+    | Placeholders must be the **entire** value | `${key}` works, `prefix_${key}` does not |
+    | Only **top-level** keys can be the root | `${dataset.attr}` references top-level `dataset`, then accesses `.attr` |
+    | Method calls support **no arguments** | `${obj.method()}` is valid, `${obj.method(42)}` is not |
+    | Arithmetic supports only **numeric** operands | String concatenation is not supported |

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,41 +1,250 @@
-# Schema Guide
+# Schema & Validation
 
-## Why?
+A schema file describes the expected shape and types of your configuration. When you provide a schema, EzConfy:
 
-Using a YAML schema lets your configuration be automatically validated with
-Pydantic.
+1. **Validates** every config value against the declared type
+2. **Returns** a Pydantic `BaseModel` instance with dot access
 
-This ensures values always match expected types (e.g. no strings where integers
-are required), reducing bugs and improving reliability.
-
-It also acts as documentation, making it easy to understand what values exist
-and how they are used.
+---
 
 ## YAML Structure
 
-A schema can contain two top-level keys:
+A schema can have two top-level keys:
 
 ```yaml
 types:
-  # type definitions
+  # custom type definitions (optional)
 
 schema:
-  # main configuration
+  # the root configuration structure
 ```
 
-If you define `types`, you must also define `schema`.
+!!! tip "Shorthand syntax"
+    If you don't need custom types, the entire file is treated as the root schema — no `types`/`schema` wrapper needed:
 
-If `types` is not present, the entire YAML is treated as the root schema.
+    ```yaml
+    lr: float
+    epochs: int
+    name: str
+    ```
 
-## Supported types
+    If you define `types`, you must also define `schema`.
 
-* **Primitives**: int, float, str, bool
-* **Optional**: type?
-* **Default values**: type = value
-* **Lists**: list[T]
-* **Unions**: A | B
-* **Nested objects**: via indentation
-* **Custom types**: defined in types
-* **Enums**: list of values
-* **Inheritance**: Child < Parent
-* **External types**: e.g. pathlib.Path
+---
+
+## Primitive Types
+
+```yaml
+lr: float
+epochs: int
+name: str
+verbose: bool
+```
+
+These map directly to Python's `float`, `int`, `str`, and `bool`.
+
+---
+
+## Optional Types
+
+Append `?` to make a field optional. It defaults to `None` if not present in the config:
+
+```yaml
+dropout: float?
+description: str?
+```
+
+---
+
+## Default Values
+
+Use `= value` to set a default:
+
+```yaml
+batch_size: int = 32
+device: str = "cpu"
+shuffle: bool = true
+```
+
+If the config file omits these fields, the defaults are used.
+
+---
+
+## Lists
+
+```yaml
+hidden_dims: list[int]
+tags: list[str]
+```
+
+!!! warning
+    The element type is validated too — `hidden_dims: [256, "oops"]` would fail validation.
+
+---
+
+## Union Types
+
+Use `|` to accept multiple types:
+
+```yaml
+value: int | float
+id: str | int
+```
+
+---
+
+## Nested Objects
+
+Indent to create a nested structure:
+
+```yaml
+training:
+  lr: float
+  epochs: int
+  batch_size: int = 32
+
+data:
+  root: str
+  num_workers: int = 4
+```
+
+This creates nested Pydantic models. Access them with `cfg.training.lr`.
+
+---
+
+## Custom Types
+
+Define reusable types in the `types` section.
+
+### Enums
+
+A list of values creates an enum:
+
+```yaml
+types:
+  OptimizerType:
+    - adam
+    - sgd
+    - rmsprop
+
+schema:
+  optimizer: OptimizerType
+```
+
+### Nested model types
+
+A dictionary creates a reusable model:
+
+```yaml
+types:
+  DataConfig:
+    root: str
+    num_workers: int = 4
+
+schema:
+  train_data: DataConfig
+  test_data: DataConfig
+```
+
+### Inheritance
+
+Use `<` to inherit from another type:
+
+```yaml
+types:
+  BaseModel:
+    name: str
+    hidden_dim: int
+
+  LargeModel < BaseModel:
+    num_layers: int
+    dropout: float
+
+schema:
+  model: LargeModel
+```
+
+`LargeModel` inherits all fields from `BaseModel` and adds its own.
+
+---
+
+## External Types
+
+Import any Python class using `module:ClassName` syntax:
+
+=== "From a package"
+
+    ```yaml
+    types:
+      Path: pathlib:Path
+      TorchModule: torch.nn:Module
+
+    schema:
+      data_root: Path
+      model: TorchModule
+    ```
+
+=== "From a file path"
+
+    ```yaml
+    model: /path/to/my_models.py:MyModel
+    ```
+
+!!! info
+    External types are validated with `isinstance` — EzConfy checks that the instantiated object is actually an instance of the declared type.
+
+---
+
+## Complete Example
+
+=== "schema.yaml"
+
+    ```yaml
+    types:
+      OptimizerType:
+        - adam
+        - sgd
+
+      TrainingConfig:
+        lr: float = 0.001
+        epochs: int = 10
+        optimizer: OptimizerType
+
+      DataConfig:
+        root: str
+        num_classes: int
+
+    schema:
+      training: TrainingConfig
+      data: DataConfig
+      name: str
+      debug: bool?
+    ```
+
+=== "config.yaml"
+
+    ```yaml
+    name: cifar-experiment
+    training:
+      lr: 0.01
+      epochs: 50
+      optimizer: adam
+    data:
+      root: ./data/cifar10
+      num_classes: 10
+    ```
+
+=== "Python"
+
+    ```python
+    cfg = ConfigBuilder.from_files(
+        config_paths="config.yaml",
+        schema_path="schema.yaml",
+    )
+
+    print(cfg.name)                  # 'cifar-experiment'
+    print(cfg.training.lr)           # 0.01
+    print(cfg.training.optimizer)    # <OptimizerType.V0: 'adam'>
+    print(cfg.data.num_classes)      # 10
+    print(cfg.debug)                 # None (optional, not provided)
+    ```

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,51 @@
+/* Hero section */
+.hero {
+  text-align: center;
+  padding: 1rem 0 0;
+}
+
+.hero img {
+  filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.15));
+}
+
+/* Feature grid cards */
+.md-typeset .grid.cards > ul > li {
+  border: 1px solid var(--md-default-fg-color--lightest);
+  border-radius: 0.5rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.md-typeset .grid.cards > ul > li:hover {
+  border-color: var(--md-accent-fg-color);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+/* Smooth page transitions */
+.md-content {
+  animation: fadeIn 0.3s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Nicer code blocks */
+.md-typeset pre > code {
+  border-radius: 0.4rem;
+}
+
+/* Tab styling */
+.md-typeset .tabbed-labels > label {
+  font-weight: 600;
+}
+
+/* Better table styling */
+.md-typeset table:not([class]) {
+  border-radius: 0.4rem;
+  overflow: hidden;
+}
+
+.md-typeset table:not([class]) th {
+  font-weight: 700;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,46 @@
-site_name: EasyConfig Documentation
+site_name: EzConfy
+site_description: YAML-based configuration with Pydantic validation and dynamic object instantiation
+site_url: https://alessioarcara.github.io/EzConfy/
+repo_url: https://github.com/alessioarcara/EzConfy
+repo_name: alessioarcara/EzConfy
+
 theme:
   name: material
+  logo: logo.svg
+  favicon: logo.svg
   palette:
-    scheme: slate
-    primary: indigo
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: deep purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  font:
+    text: Inter
+    code: JetBrains Mono
+  icon:
+    repo: fontawesome/brands/github
   features:
     - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - navigation.tabs
     - navigation.sections
+    - navigation.top
+    - navigation.footer
+    - navigation.instant
+    - navigation.instant.progress
+    - search.suggest
+    - search.highlight
+    - toc.follow
 
 plugins:
   - search
@@ -14,3 +48,42 @@ plugins:
       handlers:
         python:
           paths: [.]
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - attr_list
+  - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/alessioarcara/EzConfy
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/ezconfy/
+
+extra_css:
+  - stylesheets/extra.css
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Guides:
+      - Schema & Validation: schema.md
+      - Object Instantiation: instantiation.md
+      - Placeholders & Expressions: placeholders.md
+      - Multi-file Configs: multi-file.md
+      - Code Generation: codegen.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ezconfy"
-version = "0.1.8"
+version = "0.1.9"
 description = "YAML-based configuration framework with Pydantic validation and dynamic object instantiation"
 readme = "README.md"
 license = "MIT"

--- a/src/ezconfy/core/config_builder.py
+++ b/src/ezconfy/core/config_builder.py
@@ -52,7 +52,7 @@ class ConfigBuilder:
         if overrides:
             merged_config = self._deep_merge(merged_config, overrides)
 
-        instantiated = self.instantiator(merged_config)
+        instantiated = self.instantiator(merged_config, schema_model=self.schema_model)
 
         if self.schema_model is None:
             return instantiated

--- a/src/ezconfy/core/instantiator.py
+++ b/src/ezconfy/core/instantiator.py
@@ -2,7 +2,9 @@ import ast
 import operator as op_module
 import re
 from graphlib import CycleError, TopologicalSorter
-from typing import Any, Callable
+from typing import Any, Callable, get_args, get_origin
+
+from pydantic import BaseModel, ConfigDict, TypeAdapter
 
 from ezconfy.core.exceptions import InstantiationError
 from ezconfy.core.module_loader import ModuleLoader
@@ -32,9 +34,9 @@ class Instantiator:
     def __init__(self, module_loader: ModuleLoader | None = None) -> None:
         self._loader = module_loader if module_loader is not None else ModuleLoader()
 
-    def __call__(self, config: dict[str, Any]) -> dict[str, Any]:
+    def __call__(self, config: dict[str, Any], schema_model: type[BaseModel] | None = None) -> dict[str, Any]:
         dep_graph = self._build_dependency_graph(config)
-        return self._instantiate_topologically(config, dep_graph)
+        return self._instantiate_topologically(config, dep_graph, schema_model=schema_model)
 
     def _build_dependency_graph(self, config: dict[str, Any]) -> dict[str, set[str]]:
         graph = {}
@@ -172,19 +174,23 @@ class Instantiator:
             raise InstantiationError(f"Invalid expression '${{{expr}}}': {e}") from e
         return self._eval_node(tree.body, expr, resolved_config)
 
-    def _instantiate_obj(self, node: Any, resolved_config: dict[str, Any]) -> Any:
+    def _instantiate_obj(self, node: Any, resolved_config: dict[str, Any], schema_type: Any = None) -> Any:
         if isinstance(node, str) and (m := PLACEHOLDER_PATTERN.fullmatch(node)):
             content = m.group(1).strip()
             if _SIMPLE_PATH_RE.match(content):
-                return self._resolve_path(content, resolved_config)
-            return self._evaluate_expression(content, resolved_config)
+                result = self._resolve_path(content, resolved_config)
+            else:
+                result = self._evaluate_expression(content, resolved_config)
+            return self._try_cast(result, schema_type)
 
         if isinstance(node, dict):
             if "_target_type_" in node:
                 target = node["_target_type_"]
                 cls: Any = self._loader.load_class(target)
+                arg_types = self._get_model_field_types(schema_type)
                 resolved_args = {
-                    k: self._instantiate_obj(v, resolved_config) for k, v in node.get("_init_args_", {}).items()
+                    k: self._instantiate_obj(v, resolved_config, schema_type=arg_types.get(k))
+                    for k, v in node.get("_init_args_", {}).items()
                 }
                 init_method_name = node.get("_init_method_")
                 if init_method_name:
@@ -200,26 +206,63 @@ class Instantiator:
                 except Exception as e:
                     raise InstantiationError(f"Failed to instantiate {error_context}: {e}") from e
 
-            return {k: self._instantiate_obj(v, resolved_config) for k, v in node.items()}
+            field_types = self._get_model_field_types(schema_type)
+            return {
+                k: self._instantiate_obj(v, resolved_config, schema_type=field_types.get(k)) for k, v in node.items()
+            }
 
         if isinstance(node, list):
-            return [self._instantiate_obj(i, resolved_config) for i in node]
+            elem_type = self._get_list_element_type(schema_type)
+            return [self._instantiate_obj(i, resolved_config, schema_type=elem_type) for i in node]
 
-        return node
+        return self._try_cast(node, schema_type)
 
-    def _instantiate_topologically(self, config: dict[str, Any], graph: dict[str, set[str]]) -> dict[str, Any]:
+    def _instantiate_topologically(
+        self, config: dict[str, Any], graph: dict[str, set[str]], schema_model: type[BaseModel] | None = None
+    ) -> dict[str, Any]:
         try:
             order = list(TopologicalSorter(graph).static_order())
         except CycleError as e:
             raise InstantiationError(f"Circular reference detected in configuration: {e}") from e
 
+        top_level_types = self._get_model_field_types(schema_model)
         resolved_config: dict[str, Any] = {}
         for key in order:
             try:
-                resolved_config[key] = self._instantiate_obj(config[key], resolved_config)
+                resolved_config[key] = self._instantiate_obj(
+                    config[key], resolved_config, schema_type=top_level_types.get(key)
+                )
             except InstantiationError:
                 raise
             except Exception as e:
                 raise InstantiationError(f"Unexpected error while processing config key '{key}': {e}") from e
 
         return resolved_config
+
+    @staticmethod
+    def _try_cast(value: Any, schema_type: Any) -> Any:
+        if schema_type is None:
+            return value
+        try:
+            adapter = TypeAdapter(schema_type, config=ConfigDict(arbitrary_types_allowed=True))
+            return adapter.validate_python(value)
+        except Exception:
+            return value
+
+    @staticmethod
+    def _get_model_field_types(schema_type: Any) -> dict[str, Any]:
+        """
+        Given a Pydantic BaseModel, it returns a dict mapping field names to their annotated types.
+        This lets the instantiator know the expected type of each field, which can be used for type casting.
+        """
+        if schema_type is not None and isinstance(schema_type, type) and issubclass(schema_type, BaseModel):
+            return {name: info.annotation for name, info in schema_type.model_fields.items()}
+        return {}
+
+    @staticmethod
+    def _get_list_element_type(schema_type: Any) -> Any:
+        if schema_type is not None and get_origin(schema_type) is list:
+            args = get_args(schema_type)
+            if args:
+                return args[0]
+        return None

--- a/tests/core/test_config_builder.py
+++ b/tests/core/test_config_builder.py
@@ -325,3 +325,38 @@ wd: 0.0001
     assert cfg.wd == 0.0001
     print(type(cfg.lr))
     print(type(cfg.wd))
+
+
+def test_schema_aware_type_casting(tmp_path: Path) -> None:
+    """Schema types should be cast during instantiation: scalars and placeholders."""
+    module_content = """
+from pathlib import Path
+
+
+class Processor:
+    def __init__(self, path: Path):
+        self.path = path
+"""
+    module_file = _write_temp_yaml(tmp_path, module_content, "processor.py")
+
+    schema = f"""
+types:
+    Path: pathlib:Path
+schema:
+    data_path: Path
+    processor: {module_file}:Processor
+"""
+    config = f"""
+data_path: /some/path
+processor:
+    _target_type_: {module_file}:Processor
+    _init_args_:
+        path: ${{data_path}}
+"""
+    schema_file = _write_temp_yaml(tmp_path, schema, "schema.yaml")
+    config_file = _write_temp_yaml(tmp_path, config, "config.yaml")
+
+    cfg: Any = ConfigBuilder.from_files(config_paths=config_file, schema_path=schema_file)
+
+    assert isinstance(cfg.data_path, Path)
+    assert isinstance(cfg.processor.path, Path)

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "ezconfy"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
## Description

Add schema-aware type casting during instantiation and expand documentation.

Closes #

## Checklist

- [x] Tests added or updated for the changed behaviour
- [x] All existing tests pass (`uv run pytest`)
- [x] Type checking passes (`uv run mypy src/ezconfy --ignore-missing-imports`)
- [x] Linting passes (`uv run ruff check src tests`)
- [x] Documentation updated (docstrings, README, or docs/) if needed
- [x] `CHANGELOG.md` updated under `[Unreleased]`
