### PR TITLE
Fixed nested schema dicts not cast to BaseModel instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10] - 2026-04-22
+
+### Fixed
+- Nested schema dicts without `_target_type_` are now cast to BaseModel instances, enabling attribute access (e.g. `cfg.embed_dim` instead of `cfg['embed_dim']`)
+
 ## [0.1.9] - 2026-04-22
 
 ### Added
@@ -64,7 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - External type support (`module:ClassName` and file path syntax)
 - Topological ordering for resolving object instantiation dependencies
 
-[Unreleased]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.9...HEAD
+[Unreleased]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.10...HEAD
+[0.1.10]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/alessioarcara/EasyConfig/compare/v0.1.5...v0.1.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ezconfy"
-version = "0.1.9"
+version = "0.1.10"
 description = "YAML-based configuration framework with Pydantic validation and dynamic object instantiation"
 readme = "README.md"
 license = "MIT"

--- a/src/ezconfy/core/instantiator.py
+++ b/src/ezconfy/core/instantiator.py
@@ -207,9 +207,10 @@ class Instantiator:
                     raise InstantiationError(f"Failed to instantiate {error_context}: {e}") from e
 
             field_types = self._get_model_field_types(schema_type)
-            return {
+            result = {
                 k: self._instantiate_obj(v, resolved_config, schema_type=field_types.get(k)) for k, v in node.items()
             }
+            return self._try_cast(result, schema_type)
 
         if isinstance(node, list):
             elem_type = self._get_list_element_type(schema_type)
@@ -244,6 +245,8 @@ class Instantiator:
         if schema_type is None:
             return value
         try:
+            if isinstance(schema_type, type) and issubclass(schema_type, BaseModel):
+                return schema_type.model_validate(value)
             adapter = TypeAdapter(schema_type, config=ConfigDict(arbitrary_types_allowed=True))
             return adapter.validate_python(value)
         except Exception:

--- a/tests/core/test_config_builder.py
+++ b/tests/core/test_config_builder.py
@@ -327,6 +327,36 @@ wd: 0.0001
     print(type(cfg.wd))
 
 
+def test_nested_dict_cast_to_model_via_placeholder(tmp_path: Path) -> None:
+    module_content = """
+class Network:
+    def __init__(self, cfg):
+        self.num_classes = cfg.num_classes
+"""
+    module_file = _write_temp_yaml(tmp_path, module_content, "network.py")
+
+    schema = f"""
+schema:
+    net_config:
+        num_classes: int
+    model: {module_file}:Network
+"""
+    config = f"""
+net_config:
+    num_classes: 10
+model:
+    _target_type_: {module_file}:Network
+    _init_args_:
+        cfg: ${{net_config}}
+"""
+    schema_file = _write_temp_yaml(tmp_path, schema, "schema.yaml")
+    config_file = _write_temp_yaml(tmp_path, config, "config.yaml")
+
+    cfg: Any = ConfigBuilder.from_files(config_paths=config_file, schema_path=schema_file)
+
+    assert cfg.model.num_classes == 10
+
+
 def test_schema_aware_type_casting(tmp_path: Path) -> None:
     """Schema types should be cast during instantiation: scalars and placeholders."""
     module_content = """

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ wheels = [
 
 [[package]]
 name = "ezconfy"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
## Description

Fixed nested schema dicts not cast to BaseModel instances

Closes #

## Checklist

- [x] Tests added or updated for the changed behaviour
- [x] All existing tests pass (`uv run pytest`)
- [x] Type checking passes (`uv run mypy src/ezconfy --ignore-missing-imports`)
- [x] Linting passes (`uv run ruff check src tests`)
- [x] Documentation updated (docstrings, README, or docs/) if needed
- [x] `CHANGELOG.md` updated under `[Unreleased]`
