### PR TITLE
Add partial list overrides via `...` marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-02
+
+### Added
+- Partial list overrides: a `...` marker in an override list patches single elements (matched by `_id_` or `_target_type_`) while keeping the rest; `_delete_: true` removes an element (#57)
+
 ## [0.1.14] - 2026-07-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -183,6 +183,16 @@ cfg = ConfigBuilder.from_files(
 )
 ```
 
+Patch a single list element instead of restating the whole list — `...` keeps the other elements:
+
+```yaml
+callbacks:
+  - ...
+  - _id_: early_stopping
+    _init_args_:
+      patience: 20
+```
+
 ## Code Generation CLI
 
 Generate a Pydantic model file from a schema for editor autocompletion and static analysis:

--- a/docs/multi-file.md
+++ b/docs/multi-file.md
@@ -113,7 +113,81 @@ Nested dictionaries are merged recursively, not replaced entirely:
     ```
 
 !!! note
-    Non-dict values (scalars, lists) are fully replaced by the later file.
+    Non-dict values (scalars, lists) are fully replaced by the later file — unless the later list uses the `...` patch marker described below.
+
+---
+
+## Patching Lists
+
+Replacing a whole list just to tweak one element forces you to restate every other element. Instead, add `...` to the override list to switch it to **patch mode**: `...` expands to the base elements, and the other entries patch, add, or delete individual elements.
+
+=== "base.yaml"
+
+    ```yaml
+    callbacks:
+      - _id_: early
+        _target_type_: my_pkg.callbacks:EarlyStopping
+        _init_args_:
+          patience: 5
+      - _id_: ckpt
+        _target_type_: my_pkg.callbacks:Checkpoint
+        _init_args_:
+          save_top_k: 3
+    ```
+
+=== "override.yaml"
+
+    ```yaml
+    callbacks:
+      - ...
+      - _id_: early
+        _init_args_:
+          patience: 20
+    ```
+
+=== "Result"
+
+    ```yaml
+    callbacks:
+      - _target_type_: my_pkg.callbacks:EarlyStopping
+        _init_args_:
+          patience: 20      # patched
+      - _target_type_: my_pkg.callbacks:Checkpoint
+        _init_args_:
+          save_top_k: 3     # untouched
+    ```
+
+### Matching Rules
+
+A patch entry is matched against base elements:
+
+1. **By `_id_`** — if the entry has an `_id_`, it matches the base element with the same `_id_`. Ids exist only for matching and are stripped from the final config.
+2. **By `_target_type_`** — otherwise, it matches the first not-yet-matched base element with the same target. Two patch entries with the same target patch the first and second occurrence, in order.
+
+Matched elements are deep-merged **in place** — they keep their position in the base list, so execution order is preserved. Entries that match nothing are inserted as new elements: before `...` to prepend, after `...` to append.
+
+```yaml
+callbacks:
+  - _target_type_: my_pkg.callbacks:ProfilerStart   # new, prepended
+  - ...
+  - _target_type_: my_pkg.callbacks:ProfilerStop    # new, appended
+```
+
+### Deleting Elements
+
+Mark an entry with `_delete_: true` to remove the matched element (same matching rules):
+
+```yaml
+callbacks:
+  - ...
+  - _id_: early
+    _delete_: true
+```
+
+A `_delete_` entry that matches nothing raises a `MergeError` — typos fail loudly instead of silently keeping the element.
+
+!!! note
+    Patch mode works identically in override files and in the programmatic `overrides` dictionary (use the string `"..."` there). A list may contain at most one `...` marker.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ezconfy"
-version = "0.1.14"
+version = "0.2.0"
 description = "YAML-based configuration framework with Pydantic validation and dynamic object instantiation"
 readme = "README.md"
 license = "MIT"

--- a/src/ezconfy/__init__.py
+++ b/src/ezconfy/__init__.py
@@ -1,5 +1,5 @@
 from ezconfy.core.config_builder import ConfigBuilder
-from ezconfy.core.exceptions import EasyConfigError, InstantiationError, SchemaError
+from ezconfy.core.exceptions import EasyConfigError, InstantiationError, MergeError, SchemaError
 from ezconfy.core.schema_parser import SchemaParser
 
-__all__ = ["ConfigBuilder", "EasyConfigError", "InstantiationError", "SchemaError", "SchemaParser"]
+__all__ = ["ConfigBuilder", "EasyConfigError", "InstantiationError", "MergeError", "SchemaError", "SchemaParser"]

--- a/src/ezconfy/core/config_builder.py
+++ b/src/ezconfy/core/config_builder.py
@@ -4,13 +4,23 @@ from typing import Any
 from loguru import logger
 from pydantic import BaseModel, ValidationError
 
-from ezconfy.core.exceptions import InstantiationError
+from ezconfy.core.exceptions import InstantiationError, MergeError
 from ezconfy.core.instantiator import Instantiator
 from ezconfy.core.io import read_yaml
 from ezconfy.core.module_loader import ModuleLoader
 from ezconfy.core.schema_parser import SchemaParser
 
 PathLike = str | Path
+
+# Reserved tokens for patching lists during merge (see `_merge_list`).
+_REST_MARKER = "..."
+_ID_KEY = "_id_"
+_DELETE_KEY = "_delete_"
+
+# Reserved tokens for patching lists during merge (see `_merge_list`).
+_REST_MARKER = "..."
+_ID_KEY = "_id_"
+_DELETE_KEY = "_delete_"
 
 
 class ConfigBuilder:
@@ -29,9 +39,73 @@ class ConfigBuilder:
         for k, v in b.items():
             if k in merged and isinstance(merged[k], dict) and isinstance(v, dict):
                 merged[k] = ConfigBuilder._deep_merge(merged[k], v)
+            elif isinstance(v, list) and _REST_MARKER in v:
+                base = merged.get(k)
+                merged[k] = ConfigBuilder._merge_list(base if isinstance(base, list) else [], v)
             else:
                 merged[k] = v
         return merged
+
+    @staticmethod
+    def _merge_list(base: list[Any], patch: list[Any]) -> list[Any]:
+        """Patch ``base`` with ``patch``, where ``...`` expands to the base elements.
+
+        Patch elements are matched against base elements by ``_id_`` or, failing
+        that, by ``_target_type_`` (first unmatched occurrence). Matched elements
+        are deep-merged in place, keeping their base position; ``_delete_: true``
+        removes the matched element; unmatched patch elements are inserted at
+        their own position, before or after the ``...`` expansion.
+        """
+        if patch.count(_REST_MARKER) > 1:
+            raise MergeError("A list patch may contain at most one '...' marker.")
+
+        consumed: set[int] = set()
+
+        def find_match(el: Any) -> int | None:
+            if not isinstance(el, dict):
+                return None
+            el_id, el_target = el.get(_ID_KEY), el.get("_target_type_")
+            for i, base_el in enumerate(base):
+                if i in consumed or not isinstance(base_el, dict):
+                    continue
+                if el_id is not None:
+                    if base_el.get(_ID_KEY) == el_id:
+                        return i
+                elif el_target is not None and base_el.get("_target_type_") == el_target:
+                    return i
+            return None
+
+        patched: dict[int, Any] = {}
+        deleted: set[int] = set()
+        prefix: list[Any] = []
+        suffix: list[Any] = []
+        new_elements = prefix
+        for el in patch:
+            if el == _REST_MARKER:
+                new_elements = suffix
+                continue
+            match = find_match(el)
+            if isinstance(el, dict) and el.get(_DELETE_KEY):
+                if match is None:
+                    raise MergeError(f"List patch element marked '{_DELETE_KEY}' matches no base element: {el}")
+                consumed.add(match)
+                deleted.add(match)
+            elif match is not None:
+                consumed.add(match)
+                patched[match] = ConfigBuilder._deep_merge(base[match], el)
+            else:
+                new_elements.append(el)
+        expanded = [patched.get(i, base_el) for i, base_el in enumerate(base) if i not in deleted]
+        return prefix + expanded + suffix
+
+    @staticmethod
+    def _strip_ids(node: Any) -> Any:
+        """Recursively remove ``_id_`` keys, which only exist to match list elements."""
+        if isinstance(node, dict):
+            return {k: ConfigBuilder._strip_ids(v) for k, v in node.items() if k != _ID_KEY}
+        if isinstance(node, list):
+            return [ConfigBuilder._strip_ids(item) for item in node]
+        return node
 
     def build(
         self,
@@ -57,6 +131,7 @@ class ConfigBuilder:
 
         if overrides:
             merged_config = self._deep_merge(merged_config, overrides)
+        merged_config = self._strip_ids(merged_config)
 
         instantiated = self.instantiator(merged_config, schema_model=self.schema_model)
 

--- a/src/ezconfy/core/exceptions.py
+++ b/src/ezconfy/core/exceptions.py
@@ -8,3 +8,7 @@ class SchemaError(EasyConfigError):
 
 class InstantiationError(EasyConfigError):
     """Raised when object instantiation or configuration validation fails."""
+
+
+class MergeError(EasyConfigError):
+    """Raised when a list patch (`...` marker) is malformed or cannot be applied."""

--- a/tests/core/test_config_builder.py
+++ b/tests/core/test_config_builder.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 from ezconfy.core.config_builder import ConfigBuilder
+from ezconfy.core.exceptions import MergeError
 
 
 def _write_temp_yaml(tmpdir: Path, content: str, name: str = "config.yaml") -> Path:
@@ -144,6 +145,204 @@ training:
     assert dataset.num_classes == 50
     assert built_config["training"]["batch_size"] == 64
     assert built_config["training"]["epochs"] == 10
+
+
+def test_list_patch_by_id_keeps_rest_and_order(tmp_path: Path) -> None:
+    base = """
+steps:
+    - _id_: resize
+      size: 224
+    - _id_: normalize
+      mean: 0.5
+"""
+    override = """
+steps:
+    - ...
+    - _id_: resize
+      size: 512
+"""
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+    file2 = _write_temp_yaml(tmp_path, override, "override.yaml")
+
+    built_config: Any = ConfigBuilder.from_files(config_paths=[file1, file2])
+
+    steps = built_config["steps"]
+    assert steps == [{"size": 512}, {"mean": 0.5}]
+
+
+def test_list_patch_by_target_duplicates_consumed_in_order(fake_dataset_package: str, tmp_path: Path) -> None:
+    base = f"""
+datasets:
+    - _target_type_: {fake_dataset_package}.dataset:FakeDataset
+      _init_args_:
+          num_classes: 100
+    - _target_type_: {fake_dataset_package}.dataset:FakeDataset
+      _init_args_:
+          num_classes: 50
+"""
+    override = f"""
+datasets:
+    - ...
+    - _target_type_: {fake_dataset_package}.dataset:FakeDataset
+      _init_args_:
+          num_classes: 1
+    - _target_type_: {fake_dataset_package}.dataset:FakeDataset
+      _init_args_:
+          num_classes: 2
+"""
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+    file2 = _write_temp_yaml(tmp_path, override, "override.yaml")
+
+    built_config: Any = ConfigBuilder.from_files(config_paths=[file1, file2])
+
+    datasets = built_config["datasets"]
+    assert [d.num_classes for d in datasets] == [1, 2]
+
+
+def test_list_patch_delete_by_id_and_by_target(tmp_path: Path) -> None:
+    base = """
+callbacks:
+    - _id_: early
+      _target_type_: pkg:EarlyStopping
+    - _target_type_: pkg:Checkpoint
+    - _id_: keep
+      note: survivor
+"""
+    override = """
+callbacks:
+    - ...
+    - _id_: early
+      _delete_: true
+    - _target_type_: pkg:Checkpoint
+      _delete_: true
+"""
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+    file2 = _write_temp_yaml(tmp_path, override, "override.yaml")
+
+    built_config: Any = ConfigBuilder.from_files(config_paths=[file1, file2])
+
+    assert built_config["callbacks"] == [{"note": "survivor"}]
+
+
+def test_list_patch_delete_without_match_raises(tmp_path: Path) -> None:
+    base = """
+callbacks:
+    - _id_: early
+      patience: 5
+"""
+    override = """
+callbacks:
+    - ...
+    - _id_: missing
+      _delete_: true
+"""
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+    file2 = _write_temp_yaml(tmp_path, override, "override.yaml")
+
+    with pytest.raises(MergeError) as exc_info:
+        ConfigBuilder.from_files(config_paths=[file1, file2])
+    assert "_delete_" in str(exc_info.value)
+
+
+def test_list_patch_new_elements_prepended_and_appended(tmp_path: Path) -> None:
+    base = """
+steps:
+    - name: middle
+"""
+    override = """
+steps:
+    - name: first
+    - ...
+    - name: last
+"""
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+    file2 = _write_temp_yaml(tmp_path, override, "override.yaml")
+
+    built_config: Any = ConfigBuilder.from_files(config_paths=[file1, file2])
+
+    assert [s["name"] for s in built_config["steps"]] == ["first", "middle", "last"]
+
+
+def test_list_without_rest_marker_fully_replaced(tmp_path: Path) -> None:
+    base = """
+steps:
+    - name: one
+    - name: two
+"""
+    override = """
+steps:
+    - name: three
+"""
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+    file2 = _write_temp_yaml(tmp_path, override, "override.yaml")
+
+    built_config: Any = ConfigBuilder.from_files(config_paths=[file1, file2])
+
+    assert built_config["steps"] == [{"name": "three"}]
+
+
+def test_list_patch_multiple_rest_markers_raise(tmp_path: Path) -> None:
+    base = """
+steps:
+    - name: one
+"""
+    override = """
+steps:
+    - ...
+    - ...
+"""
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+    file2 = _write_temp_yaml(tmp_path, override, "override.yaml")
+
+    with pytest.raises(MergeError) as exc_info:
+        ConfigBuilder.from_files(config_paths=[file1, file2])
+    assert "at most one" in str(exc_info.value)
+
+
+def test_list_patch_via_overrides_dict(tmp_path: Path) -> None:
+    base = """
+steps:
+    - _id_: resize
+      size: 224
+    - _id_: normalize
+      mean: 0.5
+"""
+    overrides = {"steps": ["...", {"_id_": "resize", "size": 512}]}
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+
+    built_config: Any = ConfigBuilder.from_files(config_paths=file1, overrides=overrides)
+
+    assert built_config["steps"] == [{"size": 512}, {"mean": 0.5}]
+
+
+def test_list_patch_instantiates_patched_element(fake_dataset_package: str, tmp_path: Path) -> None:
+    base = f"""
+datasets:
+    - _id_: train
+      _target_type_: {fake_dataset_package}.dataset:FakeDataset
+      _init_args_:
+          num_classes: 100
+    - _id_: val
+      _target_type_: {fake_dataset_package}.dataset:FakeDataset
+      _init_args_:
+          num_classes: 50
+"""
+    override = """
+datasets:
+    - ...
+    - _id_: val
+      _init_args_:
+          num_classes: 25
+"""
+    file1 = _write_temp_yaml(tmp_path, base, "base.yaml")
+    file2 = _write_temp_yaml(tmp_path, override, "override.yaml")
+
+    built_config: Any = ConfigBuilder.from_files(config_paths=[file1, file2])
+
+    datasets = built_config["datasets"]
+    assert datasets[0].__class__.__name__ == "FakeDataset"
+    assert datasets[0].num_classes == 100
+    assert datasets[1].num_classes == 25
 
 
 def test_should_instantiate_with_placeholder(fake_dataset_package: str, tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #57

Override lists containing a top-level `...` marker switch to patch mode: elements are matched by `_id_` (priority) or `_target_type_` (first unmatched occurrence, duplicates consumed in order) and deep-merged in place, keeping base order. Unmatched entries are inserted before/after the `...` expansion; `_delete_: true` removes the matched element (`MergeError` if nothing matches). `_id_` keys are stripped after merging. Lists without the marker are fully replaced as before.

```yaml
callbacks:
  - ...
  - _id_: early
    _init_args_:
      patience: 20
```

- 10 new tests (52 total passing), mypy strict and ruff clean
- Docs: new "Patching Lists" section in multi-file guide, README example, CHANGELOG
- Bumps version to 0.2.0 → on merge, auto-tag creates `v0.2.0` and publish workflow releases to PyPI